### PR TITLE
Add TH version bounds

### DIFF
--- a/quickcheck-arbitrary-template.cabal
+++ b/quickcheck-arbitrary-template.cabal
@@ -25,7 +25,7 @@ Library
   Build-Depends:        base >= 4 && < 5
                       , QuickCheck
                       , safe
-                      , template-haskell
+                      , template-haskell < 2.11
 
 
 Test-Suite spec

--- a/src/Test/QuickCheck/TH/Generators/Internal.hs
+++ b/src/Test/QuickCheck/TH/Generators/Internal.hs
@@ -72,7 +72,7 @@ makeArbitrary n = withType n runConstructionApp
                          dec <- applyCon n con
                          return dec
 
--- | build the function taht applys the type constructor
+-- | build the function that applies the type constructor
 applyCon :: Name -> [Con] -> DecsQ
 applyCon n cons' = sequence [signature,value]
   where
@@ -85,7 +85,7 @@ applyCon n cons' = sequence [signature,value]
 -- Q Exp == oneOf [Gen *]
 makeArbList :: [Con] -> Q Exp
 makeArbList cons' = appE (varE 'oneof)
-                        (listE $ asNormalOrRecC applyConExp cons'  )
+                         (listE $ asNormalOrRecC applyConExp cons')
 
 -- | Normal Constructors are the only ones we are considering
 asNormalOrRecC  :: ((Name, [StrictType]) -> a) -> [Con] -> [a]


### PR DESCRIPTION
because it doesn't compile with newer versions of Template Haskell.