### PR TITLE
Allow template-haskell-2.14.

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,7 @@ dependencies:
 - base >= 4 && < 5
 - QuickCheck  
 - safe
-- template-haskell >= 2.11 && < 2.13
+- template-haskell >= 2.11 && < 2.15
 ghc-options:
 - -Wall
 #- -Werror


### PR DESCRIPTION
Required for compiling with GHC 8.6.