### PR TITLE
Support GHC 8.8 and 8.10

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: quickcheck-arbitrary-template
-version: 0.2.1.0
+version: 0.2.1.1
 synopsis: Generate QuickCheck Gen for Sum Types
 description: Building Sum Type arbitrary instance is kind of a pain. This tool helps automate the process.
 homepage: https://github.com/plow-technologies/quickcheck-arbitrary-template#readme
@@ -15,12 +15,12 @@ extra-source-files:
 
 dependencies:
 - base >= 4 && < 5
-- QuickCheck  
+- QuickCheck
 - safe
-- template-haskell >= 2.11 && < 2.15
+- template-haskell >= 2.11 && < 2.17
 ghc-options:
 - -Wall
-- -Werror
+- -Wwarn
 
 library:
   source-dirs: src

--- a/quickcheck-arbitrary-template.cabal
+++ b/quickcheck-arbitrary-template.cabal
@@ -1,0 +1,67 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           quickcheck-arbitrary-template
+version:        0.2.1.1
+synopsis:       Generate QuickCheck Gen for Sum Types
+description:    Building Sum Type arbitrary instance is kind of a pain. This tool helps automate the process.
+category:       Testing
+homepage:       https://github.com/plow-technologies/quickcheck-arbitrary-template#readme
+bug-reports:    https://github.com/plow-technologies/quickcheck-arbitrary-template/issues
+author:         Scott Murphy <scottmurphy09@gmail.com>
+maintainer:     Scott Murphy <scottmurphy09@gmail.com>
+copyright:      2016-2019 Plow Technologies
+license:        BSD3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+    ChangeLog.md
+
+source-repository head
+  type: git
+  location: https://github.com/plow-technologies/quickcheck-arbitrary-template
+
+library
+  exposed-modules:
+      Test.QuickCheck.TH.Generators
+      Test.QuickCheck.TH.Generators.Internal
+      Test.QuickCheck.TH.Generators.Internal.BuildArbitrary
+  other-modules:
+      Paths_quickcheck_arbitrary_template
+  hs-source-dirs:
+      src
+  ghc-options: -Wall -Wwarn
+  build-depends:
+      QuickCheck
+    , base >=4 && <5
+    , safe
+    , template-haskell >=2.11 && <2.17
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.QuickCheck.TH.Generators
+      Test.QuickCheck.TH.Generators.Internal
+      Test.QuickCheck.TH.Generators.Internal.BuildArbitrary
+      Test.QuickCheck.TH.GeneratorsSpec
+      Paths_quickcheck_arbitrary_template
+  hs-source-dirs:
+      src
+      test
+  ghc-options: -Wall -Wwarn
+  build-depends:
+      QuickCheck
+    , base >=4 && <5
+    , safe
+    , tasty
+    , tasty-golden
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell >=2.11 && <2.17
+  default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.30
+resolver: lts-15.6
 
 packages:
 - '.'


### PR DESCRIPTION
Updates version bound of template-haskell so that we can useUpdates version bound of template-haskell so that we can use it in GHC 8.8 and 8.10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plow-technologies/quickcheck-arbitrary-template/9)
<!-- Reviewable:end -->
